### PR TITLE
Fix UnboundLocalError when using --xml with --query

### DIFF
--- a/gcemetadata
+++ b/gcemetadata
@@ -189,6 +189,7 @@ def main():
             return
     elif len(opts) == 2:
         found_xml = None
+        outfile = None
         for opt, val in opts:
             if opt in ['-o', '--output']:
                 outfile = val


### PR DESCRIPTION
Running `gcemetadata --query instance --xml` crashes with `UnboundLocalError: local variable 'outfile' referenced before assignment` because in the `len(opts) == 2` branch, `outfile` was only assigned inside the loop when `--output` was present. When the two options are `--query` and `--xml`, the variable is never set before the `if found_xml and outfile:` check.

The fix initialises `outfile = None` before the loop, matching the pattern already used in the general opt-parsing loop below.

* Related ticket: [bsc#1269423](https://bugzilla.suse.com/show_bug.cgi?id=1269423)

## Commits

- `c9950a5` fix: initialise outfile before loop in 2-opt branch